### PR TITLE
index.md: add transistor operation tutorial

### DIFF
--- a/HelloTIP122/README.md
+++ b/HelloTIP122/README.md
@@ -1,4 +1,5 @@
 # HelloTIP122
+> Created by [Pavly G.](https://github.com/Scrappers-glitch)
 
 A showcase for the use of TIP122 with the avr gpio.
 

--- a/index.md
+++ b/index.md
@@ -74,6 +74,7 @@
 
 ### Featured Projects: 
 - [MCP3008 ADC Operation](https://software-hardware-codesign.github.io/AVR-Sandbox/HelloSPI)
+- [Basic Operation of TIP122 as a switch](https://github.com/Software-Hardware-Codesign/AVR-Sandbox/tree/master/HelloTIP122)
 - [SerialMonitor API](https://software-hardware-codesign.github.io/AVR-Sandbox/HelloJSerialComm)
 - [Serial4j API](https://software-hardware-codesign.github.io/AVR-Sandbox/wip-index.html)
 - [Static V.S. Dynamic Libraries](https://software-hardware-codesign.github.io/AVR-Sandbox/wip-index.html)


### PR DESCRIPTION
This PR includes the TIP122 tutorial to the blog site.